### PR TITLE
Bugs/health change after start

### DIFF
--- a/controllers/healthcheck_controller.go
+++ b/controllers/healthcheck_controller.go
@@ -12,21 +12,21 @@ type CheckStatus struct {
 }
 
 func HealthcheckController(checks []checks.Check, config config.Config) gin.HandlerFunc {
-	statuses := make([]CheckStatus, 0)
-	httpStatus := config.StatusOK
-	for _, check := range checks {
-		pass := check.Pass()
-		statuses = append(statuses, CheckStatus{
-			Name: check.Name(),
-			Pass: pass,
-		})
-
-		if !pass {
-			httpStatus = config.StatusNotOK
-		}
-	}
-
 	fn := func(c *gin.Context) {
+		statuses := make([]CheckStatus, 0)
+		httpStatus := config.StatusOK
+		for _, check := range checks {
+			pass := check.Pass()
+			statuses = append(statuses, CheckStatus{
+				Name: check.Name(),
+				Pass: pass,
+			})
+
+			if !pass {
+				httpStatus = config.StatusNotOK
+			}
+		}
+
 		c.JSON(httpStatus, statuses)
 	}
 


### PR DESCRIPTION
This PR address an issue with the health end point not reflecting at the time of the call the state of the components that it is monitoring. The correction is straight forward as the check should be done inside the function that handle the health point. You can check that prior to that change, the added tests do not pass and they do pass after.