### PR TITLE
Features/context check

### DIFF
--- a/checks/context_check.go
+++ b/checks/context_check.go
@@ -1,0 +1,53 @@
+package checks
+
+import (
+	"context"
+	"runtime"
+	"sync/atomic"
+)
+
+type contextCheck struct {
+	name       string
+	terminated atomic.Bool
+	ctx        context.Context
+}
+
+func NewContextCheck(ctx context.Context, name ...string) Check {
+	if len(name) > 1 {
+		panic("context check does only accept one name")
+	}
+	if ctx == nil {
+		panic("context check needs a context")
+	}
+
+	contextName := "Unknown"
+	if len(name) == 1 {
+		contextName = name[0]
+	} else {
+		pc, _, _, ok := runtime.Caller(1)
+		details := runtime.FuncForPC(pc)
+		if ok && details != nil {
+			contextName = details.Name()
+		}
+	}
+
+	c := contextCheck{
+		name: contextName,
+		ctx:  ctx,
+	}
+
+	go func() {
+		<-ctx.Done()
+		c.terminated.Store(true)
+	}()
+
+	return &c
+}
+
+func (c *contextCheck) Pass() bool {
+	return !c.terminated.Load()
+}
+
+func (c *contextCheck) Name() string {
+	return c.name
+}

--- a/checks/context_check.go
+++ b/checks/context_check.go
@@ -8,7 +8,7 @@ import (
 
 type contextCheck struct {
 	name       string
-	terminated atomic.Int32 // TODO: When the minimal supported base go version is 1.19, use atomic.Bool
+	terminated atomic.Uint32 // TODO: When the minimal supported base go version is 1.19, use atomic.Bool
 	ctx        context.Context
 }
 

--- a/checks/context_check.go
+++ b/checks/context_check.go
@@ -8,7 +8,7 @@ import (
 
 type contextCheck struct {
 	name       string
-	terminated atomic.Uint32 // TODO: When the minimal supported base go version is 1.19, use atomic.Bool
+	terminated uint32 // TODO: When the minimal supported base go version is 1.19, use atomic.Bool
 	ctx        context.Context
 }
 
@@ -38,14 +38,15 @@ func NewContextCheck(ctx context.Context, name ...string) Check {
 
 	go func() {
 		<-ctx.Done()
-		c.terminated.Store(1)
+		atomic.StoreUint32(&c.terminated, 1)
 	}()
 
 	return &c
 }
 
 func (c *contextCheck) Pass() bool {
-	return c.terminated.Load() == 0
+	v := atomic.LoadUint32(&c.terminated)
+	return v == 0
 }
 
 func (c *contextCheck) Name() string {

--- a/checks/context_check.go
+++ b/checks/context_check.go
@@ -8,7 +8,7 @@ import (
 
 type contextCheck struct {
 	name       string
-	terminated atomic.Bool
+	terminated atomic.Int32 // TODO: When the minimal supported base go version is 1.19, use atomic.Bool
 	ctx        context.Context
 }
 
@@ -38,14 +38,14 @@ func NewContextCheck(ctx context.Context, name ...string) Check {
 
 	go func() {
 		<-ctx.Done()
-		c.terminated.Store(true)
+		c.terminated.Store(1)
 	}()
 
 	return &c
 }
 
 func (c *contextCheck) Pass() bool {
-	return !c.terminated.Load()
+	return c.terminated.Load() == 0
 }
 
 func (c *contextCheck) Name() string {

--- a/checks/context_check_test.go
+++ b/checks/context_check_test.go
@@ -1,0 +1,70 @@
+package checks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContextCheck(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	assert.NotNil(t, ctx)
+	assert.NotNil(t, cancel)
+
+	c := NewContextCheck(ctx)
+
+	assert.NotNil(t, c)
+	assert.Equal(t, "github.com/tavsec/gin-healthcheck/checks.TestContextCheck", c.Name())
+	assert.True(t, c.Pass())
+
+	cancel()
+	<-ctx.Done()
+
+	// We need to give time to the goroutine to get scheduled before checking the status
+	time.Sleep(1 * time.Millisecond)
+
+	assert.False(t, c.Pass())
+}
+
+func TestContextCheckWithName(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	assert.NotNil(t, ctx)
+	assert.NotNil(t, cancel)
+
+	c := NewContextCheck(ctx, "test")
+
+	assert.NotNil(t, c)
+	assert.Equal(t, "test", c.Name())
+	assert.True(t, c.Pass())
+
+	cancel()
+	<-ctx.Done()
+
+	// We need to give time to the goroutine to get scheduled before checking the status
+	time.Sleep(1 * time.Millisecond)
+
+	assert.False(t, c.Pass())
+}
+
+func TestWrongContext(t *testing.T) {
+	assertPanic(t, func() {
+		NewContextCheck(nil)
+	})
+}
+
+func TestWrongName(t *testing.T) {
+	assertPanic(t, func() {
+		NewContextCheck(context.Background(), "test", "test2")
+	})
+}
+
+func assertPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+	f()
+}


### PR DESCRIPTION
This introduce the ability to link the health to a context and can be useful for Kubernetes autoscale scenario. This fix #16 .