### PR TITLE
Features/add notification

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,11 @@ type Config struct {
 	Method      string
 	StatusOK    int
 	StatusNotOK int
+
+	FailureNotification struct {
+		Threshold uint32
+		Chan      chan error
+	}
 }
 
 func DefaultConfig() Config {
@@ -13,5 +18,11 @@ func DefaultConfig() Config {
 		Method:      "GET",
 		StatusOK:    200,
 		StatusNotOK: 503,
+		FailureNotification: struct {
+			Threshold uint32
+			Chan      chan error
+		}{
+			Threshold: 1,
+		},
 	}
 }

--- a/controllers/healthcheck_controller_test.go
+++ b/controllers/healthcheck_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -49,6 +50,18 @@ func (c SlowCheck) Pass() bool {
 
 func (c SlowCheck) Name() string {
 	return "Slow Check"
+}
+
+type ControlledCheck struct{ willPass bool }
+
+var _ checks.Check = (*ControlledCheck)(nil)
+
+func (c *ControlledCheck) Pass() bool {
+	return c.willPass
+}
+
+func (c *ControlledCheck) Name() string {
+	return "Controlled Check"
 }
 
 func TestHealthcheckController(t *testing.T) {
@@ -142,6 +155,73 @@ func TestParallelCheckSpeed(t *testing.T) {
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	f(c)
 	assert.Less(t, time.Since(start), 3*time.Second)
+}
+
+func TestNotification(t *testing.T) {
+	router := gin.New()
+
+	controlled := &ControlledCheck{willPass: true}
+	conf := config.DefaultConfig()
+	conf.FailureNotification.Chan = make(chan error, 1)
+	defer close(conf.FailureNotification.Chan)
+	conf.FailureNotification.Threshold = 3
+
+	router.GET("/healthcheck", HealthcheckController([]checks.Check{controlled}, conf))
+
+	successResponse, err := json.Marshal([]CheckStatus{{
+		Name: "Controlled Check",
+		Pass: true,
+	}})
+	assert.NoError(t, err)
+	failureResponse, err := json.Marshal([]CheckStatus{{
+		Name: "Controlled Check",
+		Pass: false,
+	}})
+	assert.NoError(t, err)
+
+	var wg sync.WaitGroup
+	var errNotification error
+	goWaitOnChan := func() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errNotification = <-conf.FailureNotification.Chan
+		}()
+	}
+
+	goWaitOnChan()
+
+	// First, everything is good at start
+	assertRequest(t, router, "GET", "/healthcheck", "", 200, string(successResponse))
+
+	// Testing things when health goes bad
+	controlled.willPass = false
+	assertRequest(t, router, "GET", "/healthcheck", "", 503, string(failureResponse))
+	assertRequest(t, router, "GET", "/healthcheck", "", 503, string(failureResponse))
+	assertRequest(t, router, "GET", "/healthcheck", "", 503, string(failureResponse))
+
+	wg.Wait()
+	assert.Error(t, ErrHealthcheckFailed, errNotification)
+
+	// Testing things are going back to normal
+	goWaitOnChan()
+
+	controlled.willPass = true
+	assertRequest(t, router, "GET", "/healthcheck", "", 200, string(successResponse))
+
+	wg.Wait()
+	assert.NoError(t, errNotification)
+
+	// Testing finally that health is going back to bad
+	goWaitOnChan()
+
+	controlled.willPass = false
+	assertRequest(t, router, "GET", "/healthcheck", "", 503, string(failureResponse))
+	assertRequest(t, router, "GET", "/healthcheck", "", 503, string(failureResponse))
+	assertRequest(t, router, "GET", "/healthcheck", "", 503, string(failureResponse))
+
+	wg.Wait()
+	assert.Error(t, ErrHealthcheckFailed, errNotification)
 }
 
 func assertRequest(t *testing.T, router *gin.Engine, method string, path string, body string, assertStatus int, assertBody string) {

--- a/controllers/healthcheck_controller_test.go
+++ b/controllers/healthcheck_controller_test.go
@@ -48,7 +48,7 @@ func (c SlowCheck) Pass() bool {
 }
 
 func (c SlowCheck) Name() string {
-	return "Sloc Check"
+	return "Slow Check"
 }
 
 func TestHealthcheckController(t *testing.T) {


### PR DESCRIPTION
Combining this two PR and https://github.com/gin-contrib/graceful/pull/2 , it will be easy to use gin and have zero lost request on scale down in Kubernetes. As both PR haven't landed, I have not included the code in the README to use graceful shutdown, but I think that will be ultimately what I should do.

This will address #17 