### PR TITLE
Return driver name on SQL check

### DIFF
--- a/checks/sql_check.go
+++ b/checks/sql_check.go
@@ -1,6 +1,9 @@
 package checks
 
-import "database/sql"
+import (
+	"database/sql"
+	"reflect"
+)
 
 type SqlCheck struct {
 	Sql *sql.DB
@@ -10,12 +13,17 @@ func (s SqlCheck) Pass() bool {
 	if s.Sql == nil {
 		return false
 	}
-	
+
 	err := s.Sql.Ping()
 
 	return err == nil
 }
 
 func (s SqlCheck) Name() string {
-	return "mysql"
+	if s.Sql == nil {
+		return "no_driver"
+	}
+
+	driver := s.Sql.Driver()
+	return reflect.TypeOf(driver).String()
 }

--- a/checks/sql_check_test.go
+++ b/checks/sql_check_test.go
@@ -13,6 +13,11 @@ func TestSqlCheck_Pass(t *testing.T) {
 	defer db.Close()
 
 	check := SqlCheck{Sql: db}
+
+	if check.Name() != "*sqlmock.mockDriver" {
+		t.Errorf("Expected SqlCheck.Name to return '*sqlmock.mockDriver', got '" + check.Name() + "'")
+	}
+
 	if !check.Pass() {
 		t.Errorf("Expected SqlCheck.Pass to return true, got false")
 	}
@@ -25,7 +30,7 @@ func TestSqlCheck_Pass(t *testing.T) {
 
 func TestSqlCheck_Name(t *testing.T) {
 	check := SqlCheck{Sql: nil}
-	if check.Name() != "mysql" {
+	if check.Name() != "no_driver" {
 		t.Errorf("Expected SqlCheck.Name to return 'mysql', got '%s'", check.Name())
 	}
 }

--- a/controllers/healthcheck_controller_test.go
+++ b/controllers/healthcheck_controller_test.go
@@ -81,7 +81,7 @@ func TestHealthcheckControllerWithSqlCheck(t *testing.T) {
 	router.GET("/healthcheck", HealthcheckController([]checks.Check{checks.SqlCheck{Sql: db}}, conf))
 
 	response, err := json.Marshal([]CheckStatus{{
-		Name: "mysql",
+		Name: "*sqlmock.mockDriver",
 		Pass: true,
 	}})
 	assert.NoError(t, err)
@@ -112,7 +112,7 @@ func TestSwitchResultBetweenCall(t *testing.T) {
 	mock.ExpectPing().WillReturnError(nil)
 
 	response, err := json.Marshal([]CheckStatus{{
-		Name: "mysql",
+		Name: "*sqlmock.mockDriver",
 		Pass: true,
 	}})
 	assert.NoError(t, err)
@@ -121,7 +121,7 @@ func TestSwitchResultBetweenCall(t *testing.T) {
 	mock.ExpectPing().WillReturnError(driver.ErrBadConn)
 
 	response, err = json.Marshal([]CheckStatus{{
-		Name: "mysql",
+		Name: "*sqlmock.mockDriver",
 		Pass: false,
 	}})
 	assert.NoError(t, err)
@@ -139,7 +139,7 @@ func TestParallelCheck(t *testing.T) {
 	router.GET("/healthcheck", HealthcheckController([]checks.Check{checks.SqlCheck{Sql: db}, FailingCheck{}}, conf))
 
 	response, _ := json.Marshal([]CheckStatus{{
-		Name: "mysql",
+		Name: "*sqlmock.mockDriver",
 		Pass: true,
 	}, {
 		Name: "Failing Check",

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -74,7 +74,7 @@ func TestHealthcheckResponseMySqlCheck(t *testing.T) {
 	New(router, config, c)
 
 	response, err := json.Marshal([]controllers.CheckStatus{{
-		Name: "mysql",
+		Name: "*sqlmock.mockDriver",
 		Pass: true,
 	}})
 	assert.NoError(t, err)
@@ -96,7 +96,7 @@ func TestHealthcheckSwitchStateBetweenCall(t *testing.T) {
 	New(router, config, c)
 
 	response, err := json.Marshal([]controllers.CheckStatus{{
-		Name: "mysql",
+		Name: "*sqlmock.mockDriver",
 		Pass: true,
 	}})
 	assert.NoError(t, err)
@@ -105,7 +105,7 @@ func TestHealthcheckSwitchStateBetweenCall(t *testing.T) {
 	mock.ExpectPing().WillReturnError(driver.ErrBadConn)
 
 	response, err = json.Marshal([]controllers.CheckStatus{{
-		Name: "mysql",
+		Name: "*sqlmock.mockDriver",
 		Pass: false,
 	}})
 	assert.NoError(t, err)


### PR DESCRIPTION
As per https://github.com/golang/go/issues/12600, I couldn't get the best formatted driver name, but the string representation of driver's names should do (such as `*mysql.MySQLDriver`).

This closes https://github.com/tavsec/gin-healthcheck/issues/32