### PR TITLE
Redis client fix

### DIFF
--- a/checks/redis_check.go
+++ b/checks/redis_check.go
@@ -2,20 +2,24 @@ package checks
 
 import (
 	"context"
+	"time"
+
 	"github.com/redis/go-redis/v9"
 )
 
 type RedisCheck struct {
-	Client *redis.Client
+	client *redis.Client
 }
 
-func NewRedisCheck(client *redis.Client) RedisCheck {
-	check := RedisCheck{Client: client}
-	return check
+func NewRedisCheck(client *redis.Client) *RedisCheck {
+	return &RedisCheck{client: client}
 }
 
 func (r *RedisCheck) Pass() bool {
-	_, err := r.Client.Ping(context.Background()).Result()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := r.client.Ping(ctx).Result()
 	return err == nil
 }
 

--- a/checks/redis_check_test.go
+++ b/checks/redis_check_test.go
@@ -2,9 +2,9 @@ package checks
 
 import (
 	"errors"
-	"github.com/go-redis/redismock/v9"
 	"testing"
 
+	"github.com/go-redis/redismock/v9"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Redis check methods are defined for a struct pointer, but the `NewRedisCheck` returned the struct. 
Also added a context timeout, so the client won't wait for the ping indefinitely. 